### PR TITLE
Avoid use of the incompatible 'node-fetch' library

### DIFF
--- a/src/transmit.ts
+++ b/src/transmit.ts
@@ -7,7 +7,7 @@ export const transmit = async (
 ): Promise<void> => {
   const endpoint = `https://app.opslevel.com/integrations/custom_event/${CUSTOM_EVENT_WEBHOOK}`;
 
-  Promise.all(
+  await Promise.all(
     data.map(async (d) => {
       console.info(`[POST] OpsLevel: ${JSON.stringify(d)}`);
       if (!process.env.DRY_RUN)


### PR DESCRIPTION
We can risk exiting the application before all `Promise`s finish executing when transmitting data in the current implementation. 

I'm unsure whether any JS engines will actually do this and just kick off the `Promise`s and then kill them on program exit, but we might as well ensure that all `POST`s are `await`ed before allowing the control flow to continue.